### PR TITLE
Fix call to getMode to include compilerOptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_call:
 
 jobs:
   build:
@@ -31,7 +34,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Tests
         run: npm test -- -c -t0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm ci
 
       - name: Run Tests
-        run: npm test -- -c -t0
+        run: npm test -- -c -t0 --disable-coverage --allow-incomplete-coverage --allow-empty-coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish
+
+on: 
+  push:
+    branches: main
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  check-version:
+    name: "Check version"
+    runs-on: ubuntu-latest
+    outputs:
+      is_new_version: ${{ steps.get_version.outputs.IS_NEW_VERSION }}
+      version: ${{ steps.get_version.outputs.VERSION }}
+      build_date: ${{ steps.get_version.outputs.BUILD_DATE }}
+      is_prerelease: ${{ steps.get_version.outputs.IS_PRERELEASE }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check version
+        id: get_version
+        uses: digicatapult/check-version@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: 'Publish package to NPMJS'
+    needs:
+      - ci
+      - check-version
+    if: ${{ needs.check-version.outputs.is_new_version == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@digicatapult'
+      - name: Install Packages
+        run: npm ci
+      - name: Build
+        run: npm run prepare
+      - name: Publish to npmjs packages
+        run: npm run postversion
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Note: this library has been forked from https://github.com/tapjs/tsimp in order to publish a version of `tsimp` that works with `typescript` `v5.6.2` (see https://github.com/tapjs/tsimp/issues/29). There is no intent to maintain this fork at this stage and this fork will be deleted once the aforementioned issue is resolved.**
+
 # tsimp 😈
 
 A TypeScript IMPort loader for Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tsimp",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tsimp",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cached": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tsimp",
+  "name": "@digicatapult/tsimp",
   "version": "2.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tsimp",
+      "name": "@digicatapult/tsimp",
       "version": "2.0.12",
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "presnap": "npm run prepare",
     "snap": "tap",
     "test": "tap",
-    "postversion": "npm publish",
+    "postversion": "npm publish --access public",
     "prepublishOnly": "git push origin --follow-tags",
     "typedoc": "typedoc"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsimp",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "license": "BlueOak-1.0.0",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsimp",
+  "name": "@digicatapult/tsimp",
   "version": "2.0.12",
   "license": "BlueOak-1.0.0",
   "files": [

--- a/src/service/resolve-type-reference-directive-references.ts
+++ b/src/service/resolve-type-reference-directive-references.ts
@@ -58,7 +58,8 @@ export const getResolveTypeReferenceDirectiveReferences = (
       const name = loader.nameAndMode.getName(entry)
       const mode = loader.nameAndMode.getMode(
         entry,
-        containingSourceFile
+        containingSourceFile,
+        options
       )
       const key = createModeAwareCacheKey(name, mode)
       let result = rtrdrInternalCache.get(key)


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

ENG-103

## High level description

Fixes a bug from `tsimp` which makes it incompatible with Typescript 5.6.2+. Also adds publish workflows so we don't do this manually

## Detailed description

None

## Describe alternatives you've considered

Waiting for `tsimp` to merge our PR to them is an option but it's unclear when this might happen (the library appears pretty much unmaintained). This is only a temporary fix though so we can fix our build pipeline and in the long run we're going to have to look for an alternative.  

## Operational impact

None

## Additional context

None
